### PR TITLE
add 'docs' branch naming for doccumentation changes

### DIFF
--- a/standards/02-Software/05-Contribute.md
+++ b/standards/02-Software/05-Contribute.md
@@ -7,7 +7,7 @@ Ensure all links correctly resolve and names and content are updated based on yo
 <details>
   <summary><b>Click here for a copy of our contributing.md</b></summary>
 
-``````
+```
 ---
 sidebar_label: Contribution
 ---
@@ -30,13 +30,13 @@ By participating in this project, you are expected to abide by our [Code of Cond
 - **Getting Help:** If you need assistance with Overture, please create a [new discussion in our support category](https://github.com/overture-stack/docs/discussions/categories/support).
   - Before creating a new discussion, please search existing discussions to see if your question has already been answered.
 - **Feature Requests & Proposals:** We love hearing your ideas for improving Overture! Before making a feature request, please check our [**feature roadmap**](https://github.com/orgs/overture-stack/projects/11/views/1) to see if your idea is already planned.
-  - If your idea isn't on the roadmap, feel free to [**submit a feature request**](https://github.com/overture-stack/docs/discussions/categories/ideas) by creating a new discussion in our Ideas category 
+  - If your idea isn't on the roadmap, feel free to [**submit a feature request**](https://github.com/overture-stack/docs/discussions/categories/ideas) by creating a new discussion in our Ideas category
 - **Report a Potential Bug:** We use GitHub Issues primarily for tracking confirmed bugs and ticketing development tasks. If you come across a potential bug or issue, please first post it to our [**GitHub support discussion forum**](https://github.com/overture-stack/docs/discussions/categories/support).
   - This allows us to confirm the issue and gather more information if needed. If we determine that further development is required, we will create and tag you into a GitHub Issue from your discussion post.
 
 ## Our Development Process
 
-We use GitHub issues and pull requests for communication related to code changes. 
+We use GitHub issues and pull requests for communication related to code changes.
 
 ### Branch Organization
 
@@ -47,6 +47,7 @@ We use the following standard branches:
 - `feature/<name>` for feature branches
 - `release/v<version>` for release branches
 - `hotfix/<name>` for hotfix branches
+- `docs/<name>` for documentation branches
 
 ## Pull Requests
 
@@ -116,7 +117,8 @@ Guidelines for Draft Pull Requests:
 - Use the project's specified merge strategy (Typically squash and merge)
 - Delete the source branch after merging if no longer needed
 
-``````
+```
+
 </details>
 
 # Contributing to Overture
@@ -131,29 +133,28 @@ By participating in this project, you are expected to abide by our [Code of Cond
 
 **Getting Started:** Our primary platform for community support, feature requests, and general discussions is GitHub Discussions. This allows us to keep all conversations in one place and make them easily searchable for future reference.
 
-
 **Community Support:** Our primary platform for community support, feature requests, and general discussions is [GitHub Discussions](https://github.com/overture-stack/docs/discussions). This allows us to keep all conversations in one place and make them easily searchable for future reference.
 
-- **Getting Help:** If you need assistance with Overture, please create a [new discussion in our support category](https://github.com/overture-stack/docs/discussions/categories/support).
-  - Before creating a new discussion, please search existing discussions to see if your question has already been answered.
-- **Feature Requests & Proposals:** We love hearing your ideas for improving Overture! Before making a feature request, please check our [**feature roadmap**](https://github.com/orgs/overture-stack/projects/11/views/1) to see if your idea is already planned.
-  - If your idea isn't on the roadmap, feel free to [**submit a feature request**](https://github.com/overture-stack/docs/discussions/categories/ideas) by creating a new discussion in our Ideas category 
-- **Report a Potential Bug:** We use GitHub Issues primarily for tracking confirmed bugs and ticketing development tasks. If you come across a potential bug or issue, please first post it to our [**GitHub support discussion forum**](https://github.com/overture-stack/docs/discussions/categories/support).
-  - This allows us to confirm the issue and gather more information if needed. If we determine that further development is required, we will create and tag you into a GitHub Issue from your discussion post.
+-   **Getting Help:** If you need assistance with Overture, please create a [new discussion in our support category](https://github.com/overture-stack/docs/discussions/categories/support).
+    -   Before creating a new discussion, please search existing discussions to see if your question has already been answered.
+-   **Feature Requests & Proposals:** We love hearing your ideas for improving Overture! Before making a feature request, please check our [**feature roadmap**](https://github.com/orgs/overture-stack/projects/11/views/1) to see if your idea is already planned.
+    -   If your idea isn't on the roadmap, feel free to [**submit a feature request**](https://github.com/overture-stack/docs/discussions/categories/ideas) by creating a new discussion in our Ideas category
+-   **Report a Potential Bug:** We use GitHub Issues primarily for tracking confirmed bugs and ticketing development tasks. If you come across a potential bug or issue, please first post it to our [**GitHub support discussion forum**](https://github.com/overture-stack/docs/discussions/categories/support).
+    -   This allows us to confirm the issue and gather more information if needed. If we determine that further development is required, we will create and tag you into a GitHub Issue from your discussion post.
 
 ## Our Development Process
 
-We use GitHub issues and pull requests for communication related to code changes. 
+We use GitHub issues and pull requests for communication related to code changes.
 
 ### Branch Organization
 
 We use the following standard branches:
 
-- `main` is for stable production code
-- `develop` is the integration branch for new features
-- `feature/<name>` for feature branches
-- `release/v<version>` for release branches
-- `hotfix/<name>` for hotfix branches
+-   `main` is for stable production code
+-   `develop` is the integration branch for new features
+-   `feature/<name>` for feature branches
+-   `release/v<version>` for release branches
+-   `hotfix/<name>` for hotfix branches
 
 ## Pull Requests
 
@@ -185,42 +186,42 @@ We welcome and encourage pull requests from the community. To submit a pull requ
 
 8. **Include documentation updates:** If your changes affect user-facing features, update or create and issue detailing the relevant changes need to the documentation. Where appropriate include inline comments for complex code sections.
 
-10. **Be patient:** Reviewers will likely be unable to respond immediately. However, feel free to follow up politely if you haven't received feedback after a reasonable time.
+9. **Be patient:** Reviewers will likely be unable to respond immediately. However, feel free to follow up politely if you haven't received feedback after a reasonable time.
 
 ### Using Draft Pull Requests
 
 Draft Pull Requests are an excellent way to document work in progress and facilitate early feedback. Use them to:
 
-- Organize your thoughts and process
-- Share early work and ideas with the team
-- Get feedback on implementation approaches before finalizing code
-- Track progress on long-running features
+-   Organize your thoughts and process
+-   Share early work and ideas with the team
+-   Get feedback on implementation approaches before finalizing code
+-   Track progress on long-running features
 
 Guidelines for Draft Pull Requests:
 
 1. **Creation**:
-   - Open a pull request and select "Create draft pull request"
-   - Clearly mark the title with [WIP] or [DRAFT] prefix
+    - Open a pull request and select "Create draft pull request"
+    - Clearly mark the title with [WIP] or [DRAFT] prefix
 2. **Description**:
-   - Outline the current state of the work
-   - List planned tasks or improvements
-   - Highlight areas where feedback is specifically needed
+    - Outline the current state of the work
+    - List planned tasks or improvements
+    - Highlight areas where feedback is specifically needed
 3. **Updates**:
-   - Regularly update the description or provide comments following commits with progress notes
-- Use task lists (using `- [ ]` in Markdown) to track completion of sub-tasks
+    - Regularly update the description or provide comments following commits with progress notes
+
+-   Use task lists (using `- [ ]` in Markdown) to track completion of sub-tasks
+
 4. **Collaboration**:
-   - Encourage early feedback and discussion
-   - Use the pull request comments for design discussions
+    - Encourage early feedback and discussion
+    - Use the pull request comments for design discussions
 5. **Finalization**:
-   - Complete all planned work and address feedback
-   - Update tests and documentation
-   - Click "Ready for review" to move out of draft state
+    - Complete all planned work and address feedback
+    - Update tests and documentation
+    - Click "Ready for review" to move out of draft state
 
 ### Merging a Pull Request
 
-- Ensure all CI checks pass
-- Obtain the required number of approvals
-- Use the project's specified merge strategy (Typically squash and merge)
-- Delete the source branch after merging if no longer needed
-
-
+-   Ensure all CI checks pass
+-   Obtain the required number of approvals
+-   Use the project's specified merge strategy (Typically squash and merge)
+-   Delete the source branch after merging if no longer needed


### PR DESCRIPTION
# Pull Request

## Description

Add branch naming for documentation related fixes

## Type of change

Please choose only the relevant options and remove the others.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

## Checklist:

You do not need to fullfill all requirements of this checklist, select all that apply:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Additional context

Not sure why the diff is showing that I made all those changes, only added the branch naming bulletpoint